### PR TITLE
Be more accurate on the nullability of connections

### DIFF
--- a/src/connection/__tests__/__snapshots__/connection.js.snap
+++ b/src/connection/__tests__/__snapshots__/connection.js.snap
@@ -126,11 +126,11 @@ Object {
         Object {
           "name": "edges",
           "type": Object {
-            "kind": "LIST",
+            "kind": "NON_NULL",
             "name": null,
             "ofType": Object {
-              "kind": "OBJECT",
-              "name": "UserEdge",
+              "kind": "LIST",
+              "name": null,
             },
           },
         },
@@ -170,9 +170,12 @@ Object {
         Object {
           "name": "node",
           "type": Object {
-            "kind": "OBJECT",
-            "name": "User",
-            "ofType": null,
+            "kind": "NON_NULL",
+            "name": null,
+            "ofType": Object {
+              "kind": "OBJECT",
+              "name": "User",
+            },
           },
         },
       ],

--- a/src/connection/index.js
+++ b/src/connection/index.js
@@ -54,14 +54,14 @@ const connectionDefinitions = (
       # A cursor for use in pagination.
       cursor: String!
       # The item at the end of the edge
-      node: ${connectionNode}
+      node: ${connectionNode}!
       ${edgeFields ? edgeFields : ""}
     }
   
     # A connection to a list of items.
     type ${name}Connection {
       # A list of edges.
-      edges: [${name}Edge]
+      edges: [${name}Edge!]!
       # Information to aid in pagination.
       pageInfo: PageInfo!
       ${connectionFields ? connectionFields : ""}


### PR DESCRIPTION
Hello there :wave: - I'm a fan of this library, it's great work. I'm using TypeScript + Relay to really tightly couple
my API to the client, and have nullability checks set to the highest possible options. This means that I have to basically
verify all sorts of things that to my knowledge, I don't need to.

This PR updates the autogenerated types to be a bit closer to what I think reflects their actual nullability status.